### PR TITLE
Fix error when use node on mac

### DIFF
--- a/evm/host.hpp
+++ b/evm/host.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <utility>
 #include <byteswap.h>
+#include <vector>
 
 #ifdef DEBUG
 static std::string _dlog_hex(const uint8_t *p, size_t i)

--- a/lib/base16.ex
+++ b/lib/base16.ex
@@ -6,15 +6,15 @@ defmodule Base16 do
   def encode(int, bigX \\ true)
 
   def encode(int, true) when is_integer(int) do
-    "0X#{Base.encode16(:binary.encode_unsigned(int), case: :lower)}"
+    "0X#{String.replace_prefix(Base.encode16(:binary.encode_unsigned(int), case: :lower), "0", "")}"
   end
 
   def encode(int, false) when is_integer(int) do
-    "0x#{Base.encode16(:binary.encode_unsigned(int), case: :lower)}"
+    "0x#{String.replace_prefix(Base.encode16(:binary.encode_unsigned(int), case: :lower), "0", "")}"
   end
 
   def encode(hex, _bigX) do
-    "0x#{Base.encode16(hex, case: :lower)}"
+    "0x#{String.replace_prefix(Base.encode16(hex, case: :lower), "0", "")}"
   end
 
   @spec decode(<<_::16, _::_*8>>) :: binary() | non_neg_integer()

--- a/lib/network/rpc.ex
+++ b/lib/network/rpc.ex
@@ -28,11 +28,8 @@ defmodule Network.Rpc do
   def handle_jsonrpc(body_params, opts) when is_map(body_params) do
     # :io.format("handle_jsonrpc: ~p~n", [body_params])
 
-    %{
-      "method" => method,
-      "id" => id
-    } = body_params
-
+    method = Map.get(body_params, "method", "")
+    id = Map.get(body_params, "id", 0)
     params = Map.get(body_params, "params", [])
 
     {result, code, error} =
@@ -434,6 +431,9 @@ defmodule Network.Rpc do
             "type" => "reward"
           }
         ])
+
+      "" ->
+        throw(:badrequest)
 
       _ ->
         nil


### PR DESCRIPTION
It's a PR to fix some error when I use node on mac.

Since metamask had merged this PR https://github.com/MetaMask/metamask-extension/pull/9491, they added more validation on chainId.

Our chainId 15 won't be valid when client install the latest metamask (used to encoded to 0xf, but metamask required 0xf without leading 0), see: https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/pages/settings/networks-tab/network-form/network-form.component.js#L275.

Fix:

- compile error on macos because of missing header (implicit instantiation of undefined template 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >')
- Throw :badrequest when method is empty
- Remove leading 0 from encode16