### PR TITLE
Changes in support of AWS deployments to EC2

### DIFF
--- a/docker
+++ b/docker
@@ -3,16 +3,15 @@
 # Copyright 2021 Diode
 # Licensed under the Diode License, Version 1.1
 mkdir -p data_prod
+MD5=md5sum
 if [ -f "$HOME/.erlang.cookie" ]; then
     COOKIE=`cat $HOME/.erlang.cookie`
 else
     if [[ "$OSTYPE" == "darwin"* ]]
     then
         MD5=md5
-    else
-        MD5=md5sum
     fi
-    COOKIE=`echo $RANDOM | md5sum | head -c 20`
+    COOKIE=`echo $RANDOM | $MD5 | head -c 20`
     echo $COOKIE > "$HOME/.erlang.cookie"
 fi
 

--- a/docker
+++ b/docker
@@ -21,7 +21,7 @@ docker build . -t diode && \
         -d \
         --restart unless-stopped \
         --mount type=bind,source="$(pwd)/data_prod",target=/app/data_prod \
-        --name diode --rm --network=host -ti \
+        --name diode --network=host -ti \
         -e ELIXIR_ERL_OPTIONS="+sbwt none -noinput -noshell -sname diode +A 8 -setcookie $COOKIE" \
         -e MIX_ENV=prod \
         -e PORT=8080 \

--- a/docker
+++ b/docker
@@ -6,12 +6,20 @@ mkdir -p data_prod
 if [ -f "$HOME/.erlang.cookie" ]; then
     COOKIE=`cat $HOME/.erlang.cookie`
 else
+    if [[ "$OSTYPE" == "darwin"* ]]
+    then
+        MD5=md5
+    else
+        MD5=md5sum
+    fi
     COOKIE=`echo $RANDOM | md5sum | head -c 20`
     echo $COOKIE > "$HOME/.erlang.cookie"
 fi
 
 docker build . -t diode && \
     exec docker run \
+        -d \
+        --restart unless-stopped \
         --mount type=bind,source="$(pwd)/data_prod",target=/app/data_prod \
         --name diode --rm --network=host -ti \
         -e ELIXIR_ERL_OPTIONS="+sbwt none -noinput -noshell -sname diode +A 8 -setcookie $COOKIE" \

--- a/guides/running_your_miner.md
+++ b/guides/running_your_miner.md
@@ -18,7 +18,7 @@ This dataset contains the first 3 million validated blocks and will speed up you
 
 1. Download the pre-validate file `wget http://eu2.prenet.diode.io:8000/blockchain.sq3.xz`
 1. Check the md5-checksum to be `f5285a5827611e159073985ebefc47d2`
-1. Move the file to `prod_data/blockchain.sq3.xz`
+1. Move the file to `data_prod/blockchain.sq3.xz`
 1. Extra the file using xz `xz -d blockchain.sq3.xz`
 
 ## Managing Stake


### PR DESCRIPTION
# PR Summary
I have created a project for automating the deployment of a Diode server/miner to AWS EC2. 

These changes are in support of my CDK project https://github.com/williamcharltonengineering/cdk-ec2-diode-server

Please leave github handles in the PR so I can add you to the repo and you can view/clone/play.

## docker script

- add check for OSX for `md5` sum checks
- change from `--rm` to `-d --restart unless-stopped`

## guides/running_your_miner.md

- change `prod_data` to `data_prod` as I believe it is a typo and when I changed it I got the desired behavior.