### PR TITLE
fix: update elixir version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Diode Server
 # Copyright 2021 Diode
 # Licensed under the Diode License, Version 1.1
-FROM elixir:1.11.4
+FROM elixir:1.12
 
 RUN apt-get update && apt-get install -y libboost-dev libboost-system-dev
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Diode.Mixfile do
   def project do
     [
       app: Diode,
-      elixir: "~> 1.11",
+      elixir: "~> 1.12",
       version: :persistent_term.get(:vsn, @vsn),
       full_version: :persistent_term.get(:full_vsn, @full_vsn),
       source_url: @url,


### PR DESCRIPTION
`Range.new/3` is only supported in Elixir 12+

https://hexdocs.pm/elixir/1.12/Range.html#new/3

```
#0 11.17 Compiling 79 files (.ex)
#0 11.19 
#0 11.19 20:41:46.253 [info]  Child :disk_log_sup of Supervisor :kernel_safe_sup started
#0 11.19 Pid: #PID<0.206.0>
#0 11.19 Start Call: :disk_log_sup.start_link()
#0 11.19 Restart: :permanent
#0 11.19 Shutdown: 1000
#0 11.19 Type: :supervisor
#0 11.19 
#0 11.19 20:41:46.263 [info]  Child :disk_log_server of Supervisor :kernel_safe_sup started
#0 11.19 Pid: #PID<0.207.0>
#0 11.19 Start Call: :disk_log_server.start_link()
#0 11.19 Restart: :permanent
#0 11.19 Shutdown: 2000
#0 11.19 Type: :worker
#0 13.99 warning: Range.new/3 is undefined or private. Did you mean one of:
#0 13.99 
#0 13.99       * new/2
#0 13.99 
#0 13.99   lib/model/chainsql.ex:591: Model.ChainSql.recompress_blocks/0
#0 13.99 
#0 14.00 Compilation failed due to warnings while using the --warnings-as-errors option
------
Dockerfile:18
--------------------
  16 |     COPY . /app/
  17 |     
  18 | >>> RUN mix do compile, git_version
  19 |     
  20 |     #CMD ["elixir", "-S", "mix", "run", "--no-halt"]
--------------------
ERROR: failed to solve: process "/bin/sh -c mix do compile, git_version" did not complete successfully: exit code: 1
```