### PR TITLE
fix: ensure correct address printout on startup

### DIFF
--- a/lib/model/credsql.ex
+++ b/lib/model/credsql.ex
@@ -32,11 +32,6 @@ defmodule Model.CredSql do
       """)
     end)
 
-    ensure_identity()
-    Diode.puts("====== Coinbase ======")
-    Diode.puts("#{Wallet.printable(Diode.miner())}")
-    Diode.puts("")
-
     case Diode.get_env_int("PRIVATE", 0) do
       # Decode env parameter such as
       # export PRIVATE="0x123456789"
@@ -48,6 +43,10 @@ defmodule Model.CredSql do
         |> Wallet.from_privkey()
         |> set_wallet()
     end
+
+    Diode.puts("====== Coinbase ======")
+    Diode.puts("#{Wallet.printable(Diode.miner())}")
+    Diode.puts("")
 
     {:ok, %{}}
   end


### PR DESCRIPTION
If there is already an address written to `wallet.sql` but the private key is specified via an environment variable, the server will print out the address from the `wallet.sql` on startup, even though it's actually using the key from the environment variable.